### PR TITLE
fix: 명함 수정 페이지 머지 충돌 해결

### DIFF
--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -1,6 +1,9 @@
+import axios from 'axios';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useCreateCard } from '@/hooks/queries/useCreateCard';
+import { useUpdateCard } from '@/hooks/queries/useUpdateCard';
 
 interface Data {
   nickname: string;
@@ -8,7 +11,7 @@ interface Data {
   instagramId: string;
   githubId: string;
   blog: string;
-  hashtag: string;
+  hashtag: string[];
   password: string;
   customFields: CustomFields[];
 }
@@ -18,9 +21,16 @@ interface CustomFields {
   contents: string;
 }
 
-const CardForm = () => {
+const CardForm = ({ cardId }: { cardId: string }) => {
+  console.log('cardId cardForm: ', cardId);
   const router = useRouter();
   const { mutate: createCard } = useCreateCard();
+  const { mutate: updateCard } = useUpdateCard();
+  const [hashtags, setHashtags] = useState<string[]>([]);
+  const [hashtagInput, setHashtagInput] = useState('');
+  const [showDropdown, setShowDropdown] = useState(false);
+  const res = axios.get(`/api/cards/${cardId}`).then((res) => res.data.foundCard);
+  console.log('res: ', res);
   const {
     register,
     handleSubmit,
@@ -28,19 +38,33 @@ const CardForm = () => {
     formState: { errors },
     setValue,
   } = useForm<Data>({
-    defaultValues: {
-      nickname: '',
-      twitter: '',
-      instagramId: '',
-      githubId: '',
-      blog: '',
-      hashtag: '',
-      password: '',
-      customFields: [],
-    },
+    defaultValues: async () => await axios.get(`/api/cards/${cardId}`).then((res) => res.data.foundCard),
   });
+  // { defaultValues: async () => axios.get(`/api/cards/${cardId}`).then((res) => res.data.foundCard) })
+  const removeHashtag = (index: number) => {
+    setHashtags((prevHashtags) => prevHashtags.filter((_, i) => i !== index));
+  };
+
+  const handleHashtagInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!event.nativeEvent.isComposing && event.key === 'Enter') {
+      event.preventDefault();
+      const newHashtag = (event.target as HTMLInputElement).value.trim();
+
+      if (newHashtag && !hashtags.includes(newHashtag)) {
+        setHashtags([...hashtags, newHashtag]); // 새 해시태그 추가
+        setHashtagInput('');
+        setShowDropdown(false);
+      }
+    }
+    setShowDropdown(true);
+  };
+
+  const handleHashtagInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setHashtagInput(event.target.value);
+  };
 
   const onSubmit = (data: Data) => {
+    console.log('data: ', data);
     const allData = {
       customFields: data.customFields,
       socialMedia: { instagram: data.instagramId, github: data.githubId, blog: data.blog },
@@ -50,7 +74,9 @@ const CardForm = () => {
       password: data.password,
     };
 
-    createCard(allData, {
+    const hook = router.pathname === '/[id]/edit' ? createCard : updateCard;
+    console.log('allData: ', allData);
+    hook(allData, {
       onSuccess: (data) => {
         router.push(`/${data.data.newCard[0].id}`);
       },
@@ -67,77 +93,176 @@ const CardForm = () => {
   const blog = watch('blog');
   const hashtag = watch('hashtag');
 
+  const Dropdown = () =>
+    hashtagInput && (
+      <ul className="p-2 shadow w-full max-w-xs menu dropdown-content z-[1] bg-base-100 rounded-box">
+        <li>
+          <div className="badge badge-outline flex items-center justify-center">#{hashtagInput}</div>
+        </li>
+      </ul>
+    );
+
   return (
     <div className="pb-12">
-      <div className="border-2 border-black aspect-nameCard">
-        <div>닉네임: {nickname}</div>
-        <div>트위터 아이디: {twitter}</div>
-        <div>해시태그: {hashtag}</div>
-        <div>인스타 아이디: {instagramId}</div>
-        <div>깃허브 아이디: {githubId}</div>
-        <div>블로그 주소: {blog}</div>
-      </div>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4 py-5">
-        {/* maxLength는 임시값 */}
-        <div>
-          비밀번호
-          <input type="password" {...register('password', { required: true })} name="password" />
-          {errors.password && requiredSentence}
+      <div className="card glass bg-white shadow-md aspect-nameCard">
+        <div className="card-body">
+          <h1>{nickname}</h1>
+          <div>{twitter ? `@${twitter}` : ''}</div>
+          <div>{hashtags}</div>
+          <div>{instagramId}</div>
+          <div>{githubId}</div>
+          <div>{blog}</div>
+          <div>{hashtag}</div>
         </div>
-        <label>
-          닉네임
-          <input {...register('nickname', { required: true, maxLength: 10 })} name="nickname" />
-          {errors.twitter && requiredSentence}
-        </label>
-        <label>
-          트위터 아이디
-          <input {...register('twitter', { required: true, maxLength: 10 })} name="twitter" />
-          {errors.twitter && requiredSentence}
-        </label>
-        <label>
-          해시태그
-          <input {...register('hashtag', { maxLength: 10 })} name="hashtag" />
-        </label>
-        <fieldset className="flex flex-col gap-2">
-          <legend>SNS 아이디</legend>
-          <label>
-            인스타
-            <input {...register('instagramId', { maxLength: 10 })} name="instagramId" />
+      </div>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col py-5">
+        {/* maxLength는 임시값 */}
+        <fieldset>
+          <legend className="font-bold">명함정보</legend>
+          <label className="form-control w-full max-w-xs">
+            <div className="label">
+              <span className="label-text">닉네임</span>
+            </div>
+            <input
+              type="text"
+              placeholder=""
+              className="input w-full max-w-xs shadow-sm"
+              {...register('nickname', { required: true })}
+              name="nickname"
+            />
+            <div className="label">
+              <span className="label-text text-red-500 font-semibold">{errors.twitter && requiredSentence}</span>
+            </div>
           </label>
-          <label>
-            깃허브
-            <input {...register('githubId', { maxLength: 10 })} name="githubId" />
+          <label className="form-control w-full max-w-xs">
+            <div className="label">
+              <span className="label-text">트위터 아이디</span>
+            </div>
+            <input
+              type="text"
+              placeholder=""
+              className="input w-full max-w-xs shadow-sm"
+              {...register('twitter', { required: true })}
+              name="twitterId"
+            />
+            <div className="label">
+              <span className="label-text text-red-500 font-semibold"> {errors.twitter && requiredSentence}</span>
+            </div>
           </label>
-          <label>
-            블로그
-            <input {...register('blog')} name="blog" />
+          <label className="form-control w-full max-w-xs">
+            <div className="label">
+              <span className="label-text">해시태그</span>
+            </div>
+            <input
+              type="text"
+              placeholder=""
+              className="input w-full max-w-xs shadow-sm"
+              value={hashtagInput}
+              {...register('hashtag')}
+              onChange={handleHashtagInputChange}
+              onKeyDown={handleHashtagInputKeyDown}
+              name="hashtag"
+            />
+            {showDropdown && <Dropdown />}
+            <div className="flex flex-wrap gap-2 mt-2">
+              {hashtags?.map((hashtag, index) => (
+                <div
+                  className="badge border-none bg-slate-100 text-slate-400 flex items-center justify-center"
+                  key={index}
+                >
+                  #{hashtag}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    className="inline-block w-4 h-4 stroke-current cursor-pointer"
+                    onClick={() => removeHashtag(index)}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path>
+                  </svg>
+                </div>
+              ))}
+            </div>
+            <div className="label">
+              <span className="label-text text-red-500 font-semibold"> {errors.hashtag && requiredSentence}</span>
+            </div>
           </label>
         </fieldset>
+        <fieldset className="flex flex-col">
+          <legend className="font-bold">소셜 미디어</legend>
+          <label>
+            <div className="label">
+              <span className="label-text">인스타그램</span>
+            </div>
+            <input
+              type="text"
+              placeholder=""
+              className="input w-full max-w-xs shadow-sm"
+              {...register('instagramId')}
+              name="instagramId"
+            />
+          </label>
+          <label>
+            <div className="label">
+              <span className="label-text">깃허브</span>
+            </div>
+            <input
+              type="text"
+              placeholder=""
+              className="input w-full max-w-xs shadow-sm"
+              {...register('githubId')}
+              name="githubId"
+            />
+          </label>
+          <label>
+            <div className="label">
+              <span className="label-text">블로그</span>
+            </div>
+            <input
+              type="text"
+              placeholder=""
+              className="input w-full max-w-xs shadow-sm"
+              {...register('blog')}
+              name="blog"
+            />
+          </label>
+        </fieldset>
+        <fieldset>
+          {watch('customFields')?.map((_, index) => (
+            <div className="flex flex-col gap-2 my-2" key={index}>
+              <label>
+                제목
+                <input
+                  type="text"
+                  className="input w-full shadow-sm placeholder:text-sm"
+                  {...register(`customFields.${index}.key`)}
+                />
+              </label>
+              <label>
+                내용
+                <textarea
+                  className="min-h-24 resize-y textarea shadow-sm"
+                  {...register(`customFields.${index}.contents`)}
+                />
+              </label>
+            </div>
+          ))}
 
-        {watch('customFields').map((_, index) => (
-          <div key={index}>
-            <label>
-              제목
-              <input type="text" {...register(`customFields.${index}.key`)} />
-            </label>
-            <label>
-              내용
-              <textarea {...register(`customFields.${index}.contents`)} />
-            </label>
-          </div>
-        ))}
+          <button
+            type="button"
+            className="w-full h-10 mt-2 bg-primary text-white hover:brightness-95 focus:outline-none font-medium rounded-lg text-sm px-5 py-2.5 flex justify-center items-center mb-2"
+            onClick={() => setValue('customFields', [...watch('customFields'), { key: '', contents: '' }])}
+          >
+            자유형식 항목 추가하기
+          </button>
 
-        <button
-          type="button"
-          className="w-full h-10 bg-primary"
-          onClick={() => setValue('customFields', [...watch('customFields'), { key: '', contents: '' }])}
-        >
-          자유형식 항목 추가하기
-        </button>
-
-        <button type="submit" className="btm-nav btm-nav-md max-w-[512px] mx-auto z-20 bg-accent text-white font-bold">
-          저장하기
-        </button>
+          <button
+            type="submit"
+            className="btm-nav btm-nav-md max-w-[512px] mx-auto z-20 bg-accent text-white font-bold"
+          >
+            저장하기
+          </button>
+        </fieldset>
       </form>
     </div>
   );

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -148,7 +148,7 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
           <div>{hashtag}</div>
         </div>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col py-5">
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col py-5 gap-10">
         {/* maxLength는 임시값 */}
         <fieldset>
           <legend className="font-bold">명함정보</legend>
@@ -261,41 +261,38 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
           </label>
         </fieldset>
         <fieldset>
+          <legend className="font-bold">자유 형식</legend>
           {watch('customFields')?.map((_, index) => (
             <div className="flex flex-col gap-2 my-2" key={index}>
               <label>
-                제목
                 <input
                   type="text"
+                  placeholder="자유형식 제목"
                   className="input w-full shadow-sm placeholder:text-sm"
                   {...register(`customFields.${index}.key`)}
                 />
               </label>
               <label>
-                내용
                 <textarea
-                  className="min-h-24 resize-y textarea shadow-sm"
+                  placeholder="자유형식 내용"
+                  className="min-h-24 resize-y textarea shadow-sm w-full placeholder:text-sm"
                   {...register(`customFields.${index}.contents`)}
                 />
               </label>
             </div>
           ))}
-
-          <button
-            type="button"
-            className="w-full h-10 mt-2 bg-primary text-white hover:brightness-95 focus:outline-none font-medium rounded-lg text-sm px-5 py-2.5 flex justify-center items-center mb-2"
-            onClick={() => setValue('customFields', [...watch('customFields'), { key: '', contents: '' }])}
-          >
-            자유형식 항목 추가하기
-          </button>
-
-          <button
-            type="submit"
-            className="btm-nav btm-nav-md max-w-[512px] mx-auto z-20 bg-accent text-white font-bold"
-          >
-            저장하기
-          </button>
         </fieldset>
+        <button
+          type="button"
+          className="w-full h-12 mt-2 bg-primary text-white hover:brightness-95 focus:outline-none font-medium rounded-lg text-sm px-5 py-2.5 flex justify-center items-center mb-2"
+          onClick={() => setValue('customFields', [...watch('customFields'), { key: '', contents: '' }])}
+        >
+          자유형식 항목 추가하기
+        </button>
+
+        <button type="submit" className="btm-nav btm-nav-md max-w-[512px] mx-auto z-20 bg-accent text-white font-bold">
+          저장하기
+        </button>
       </form>
     </div>
   );

--- a/src/hooks/queries/useCreateCard.ts
+++ b/src/hooks/queries/useCreateCard.ts
@@ -13,7 +13,7 @@ interface SubmittedCard {
   };
   nickname: string;
   twitter: string;
-  hashtag: string;
+  hashtags: string[];
   password: string;
 }
 

--- a/src/hooks/queries/useUpdateCard.ts
+++ b/src/hooks/queries/useUpdateCard.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+
+interface SubmittedCard {
+  customFields: {
+    key: string;
+    contents: string;
+  }[];
+  socialMedia: {
+    instagram: string;
+    github: string;
+    blog: string;
+  };
+  nickname: string;
+  twitter: string;
+  hashtag: string;
+  password: string;
+}
+
+export const useUpdateCard = () => {
+  return useMutation({
+    mutationFn: (data: SubmittedCard) => {
+      return axios.put(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/cards`, data);
+    },
+  });
+};

--- a/src/hooks/queries/useUpdateCard.ts
+++ b/src/hooks/queries/useUpdateCard.ts
@@ -2,25 +2,29 @@ import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 
 interface SubmittedCard {
-  customFields: {
-    key: string;
-    contents: string;
-  }[];
-  socialMedia: {
-    instagram: string;
-    github: string;
-    blog: string;
+  cardId: string;
+  allData: {
+    customFields: {
+      key: string;
+      contents: string;
+    }[];
+    socialMedia: {
+      instagram: string;
+      github: string;
+      blog: string;
+    };
+    nickname: string;
+    twitter: string;
+    hashtags: string[];
+    password: string;
   };
-  nickname: string;
-  twitter: string;
-  hashtag: string;
-  password: string;
 }
 
 export const useUpdateCard = () => {
   return useMutation({
     mutationFn: (data: SubmittedCard) => {
-      return axios.put(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/cards`, data);
+      console.log('data.allData: ', data.allData);
+      return axios.put(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/cards/${data.cardId}`, data.allData);
     },
   });
 };

--- a/src/pages/[id]/edit/index.tsx
+++ b/src/pages/[id]/edit/index.tsx
@@ -1,12 +1,22 @@
+import { GetServerSidePropsContext } from 'next';
 import CardForm from '@/components/card/CardForm';
 import LayoutWithTitle from '@/components/layout/LayoutWithTitle';
 
-const Page = () => {
-  return <CardForm />;
+const Page = ({ cardId }: { cardId: string }) => {
+  console.log('cardId front: ', cardId);
+  return <CardForm cardId={cardId} />;
 };
 
 Page.getLayout = function getLayout(page) {
   return <LayoutWithTitle title="명함 수정하기">{page}</LayoutWithTitle>;
+};
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const cardId = context.params?.id;
+  console.log('cardId: ', cardId);
+  return {
+    props: { cardId },
+  };
 };
 
 export default Page;

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -8,6 +8,7 @@ import type { GetServerSidePropsContext } from 'next';
 import type { CardType } from '@/types/cards';
 
 const Page = ({ card }: { card: CardType }) => {
+  console.log('card: ', card);
   const path = `/${card.id}/login`;
 
   const handleShowBottomSheet = () => {
@@ -46,13 +47,23 @@ const Page = ({ card }: { card: CardType }) => {
           </Link>
         </div>
       </div>
-      <div className="pt-5">
-        {card.customFields?.map((field) => (
-          <div key={card.twitter} className="flex flex-col pb-5">
-            <div className="text-sm font-bold pb-1">{field.key}</div>
-            <div className="text-lg">{field.contents}</div>
-          </div>
-        ))}
+      <div>
+        <div className="pt-5 ">
+          <div className="text-sm font-bold pb-1">소셜 미디어</div>
+          <div className="text-lg">트위터: {card.twitter}</div>
+          <div className="text-lg">인스타그램: {card.socialMedia?.instagram}</div>
+          <div className="text-lg">깃허브: {card.socialMedia?.github}</div>
+          <div className="text-lg">블로그: {card.socialMedia?.blog}</div>
+        </div>
+        <div className="pt-5 ">
+          {card.customFields?.map((field) => (
+            <div key={card.twitter} className="flex flex-col pb-5">
+              <div className="text-sm font-bold pb-1">{field.key}</div>
+              <div className="text-lg">{field.contents}</div>
+            </div>
+          ))}
+        </div>
+        <div className="pt-5 ">해시태그: {card.hashtag}</div>
       </div>
     </>
   );

--- a/src/pages/default/edit/index.tsx
+++ b/src/pages/default/edit/index.tsx
@@ -1,20 +1,12 @@
-import { GetServerSidePropsContext } from 'next';
 import CardForm from '@/components/card/CardForm';
 import LayoutWithTitle from '@/components/layout/LayoutWithTitle';
 
-const Page = (cardId: string) => {
-  return <CardForm cardId={cardId} />;
+const Page = () => {
+  return <CardForm cardId={null} />;
 };
 
 Page.getLayout = function getLayout(page) {
   return <LayoutWithTitle title="명함 만들기">{page}</LayoutWithTitle>;
-};
-
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const cardId = context.params?.id;
-  return {
-    props: { cardId },
-  };
 };
 
 export default Page;

--- a/src/pages/default/edit/index.tsx
+++ b/src/pages/default/edit/index.tsx
@@ -1,12 +1,20 @@
+import { GetServerSidePropsContext } from 'next';
 import CardForm from '@/components/card/CardForm';
 import LayoutWithTitle from '@/components/layout/LayoutWithTitle';
 
-const Page = () => {
-  return <CardForm />;
+const Page = (cardId: string) => {
+  return <CardForm cardId={cardId} />;
 };
 
 Page.getLayout = function getLayout(page) {
   return <LayoutWithTitle title="명함 만들기">{page}</LayoutWithTitle>;
+};
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const cardId = context.params?.id;
+  return {
+    props: { cardId },
+  };
 };
 
 export default Page;


### PR DESCRIPTION
## 작업 내용
- 명함 수정 페이지와 명함 수정 페이지의 ui 관련 pr과 머지하다가 발생한 충돌을 해결하였습니다. 
- 머지한 브랜치에서 충돌을 해결하지 못해 해당 브랜치를 만들어서 해결하였습니다.

## 스크린샷
<img width="200" alt="스크린샷 2024-02-12 오전 10 03 00" src="https://github.com/ramgee-zzik-nabi/application/assets/101965666/7909c387-b923-450c-ad70-1d84ab22bf69">
<img width="200" alt="스크린샷 2024-02-12 오전 10 03 21" src="https://github.com/ramgee-zzik-nabi/application/assets/101965666/81e44ad0-494e-4695-b675-54bbf9f428df">
<img width="200" alt="스크린샷 2024-02-12 오전 10 03 28" src="https://github.com/ramgee-zzik-nabi/application/assets/101965666/aaa46648-dbc0-492f-976d-2bb0748f2250">


## 고민되는 부분
- 스크린샷에서 볼 수 있듯이, 명함을 생성/수정할 때 한 페이지에서 생성/수정이 끝나지 않습니다. 너무 폼이 길어서 줄여야 할지 고민이 됩니다.(ui 수정이 필요할지)
- 자유 형식 필드를 추가하는 기능만 있고, 삭제하는 기능이 없어 삭제 기능을 추가해야 할지 고민됩니다.
- 명함을 수정할 때 특정 필드에서 기존 폼 데이터를 받아오지 못하고 있습니다.(인스타, 깃허브, 블로그를 포함하는 소셜미디어 필드, 그리고 해시태그 필드) 이 부분에서 도움이 필요할 것 같습니다🥲
