### PR TITLE
feat: 삭제 api 연결

### DIFF
--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -8,8 +8,6 @@ import type { GetServerSidePropsContext } from 'next';
 import type { CardType } from '@/types/cards';
 
 const Page = ({ card }: { card: CardType }) => {
-  const path = `/${card.id}/login`;
-
   const handleShowBottomSheet = () => {
     NiceModal.show(BottomSheet);
   };
@@ -36,11 +34,17 @@ const Page = ({ card }: { card: CardType }) => {
           <div className="text-sm">명함 전달하기</div>
         </button>
         <div className="flex justify-center items-center">
-          <Link href={path} className="w-16 btn-secondary flex flex-col justify-center items-center">
+          <Link
+            href={`/${card.id}/login?mode=edit`}
+            className="w-16 btn-secondary flex flex-col justify-center items-center"
+          >
             <Image src="/edit.png" width={25} height={25} alt="수정 이미지" />
             <div className="text-sm">수정하기</div>
           </Link>
-          <Link href={path} className="w-16 btn-secondary flex flex-col justify-center items-center">
+          <Link
+            href={`/${card.id}/login?mode=delete`}
+            className="w-16 btn-secondary flex flex-col justify-center items-center"
+          >
             <Image src="/delete.png" width={25} height={25} alt="삭제 이미지" />
             <div className="text-sm">삭제하기</div>
           </Link>

--- a/src/pages/[id]/login/index.tsx
+++ b/src/pages/[id]/login/index.tsx
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import LayoutWithTitle from '@/components/layout/LayoutWithTitle';
@@ -13,22 +14,38 @@ const Page: NextPageWithLayout = () => {
 
   const router = useRouter();
   const cardId = router.query.id as string;
-  const path = `/${cardId}/edit`;
+  const mode = router.query.mode;
 
   const handleSubmitHandler = (data: Password) => {
-    postPassword(
-      {
-        cardId,
-        password: data.password,
-      },
-      {
-        onSuccess: () => {
-          console.log(cardId, data.password);
-          console.log('성공');
-          router.push(path);
-        },
-      },
-    );
+    switch (mode) {
+      case 'edit':
+        postPassword(
+          {
+            cardId,
+            password: data.password,
+          },
+          {
+            onSuccess: () => {
+              router.push(`/${cardId}/edit`);
+            },
+          },
+        );
+        break;
+      case 'delete':
+        postPassword(
+          {
+            cardId,
+            password: data.password,
+          },
+          {
+            onSuccess: () => {
+              axios.delete(`/api/cards/${cardId}`);
+              router.push('/');
+            },
+          },
+        );
+        break;
+    }
   };
 
   const {


### PR DESCRIPTION
## 작업 내용
- 명함 삭제 api를 연결하였습니다.
- 명함 삭제 시에 비밀번호 확인을 거치는데, 명함 수정 시에도 동일한 로그인 페이지를 사용하여 비밀번호를 확인하고 있습니다. 따라서 쿼리스트링으로 경로에 `?mode=` 를 넣어 수정을 위해 로그인 페이지에 접속했는지(`/[cardId]/login?mode=edit`), 삭제를 위해 로그인 페이지에 접속했는지(`/[cardId]/login?mode=edit`) 알 수 있도록 하였습니다.
- 삭제를 위해 로그인 페이지에 접속했을 시에는 삭제 요청 후 메인 페이지로 이동하도록 설정하였습니다.

## 고민되는 부분
- url의 mode를 직접 조작하여 접속 시 문제가 생기지 않을지 고민됩니다. 만약 수정을 위해 로그인을 했는데 url에서 mode를 delete로 바꿔서 명함이 삭제되었다면 이부분은 사용자의 과실로 보고 개발하는 입장에서는 따로 신경쓰지 않아도 되는 부분일까요?