### PR TITLE
feat: 메인 페이지 각 카드 UI 변경

### DIFF
--- a/src/components/card/CardItem.tsx
+++ b/src/components/card/CardItem.tsx
@@ -1,12 +1,20 @@
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { applyDateFormatting } from '@/utils/applyDateFormatting';
+import { checkIsNew } from '@/utils/checkIsNew';
 import type { CardType } from '@/types/cards';
 
 const CardItem = ({ card }: { card: CardType }) => {
-  console.log(card);
+  const [isNew, setIsNew] = useState(false);
   const router = useRouter();
   const openDetailPageHandler = () => {
     router.push(`/${card.id}`);
   };
+
+  useEffect(() => {
+    const isNew = checkIsNew(card.updated_at);
+    setIsNew(isNew);
+  }, [card.updated_at]);
 
   return (
     // Todo: 명함 컴포넌트 만들기
@@ -14,19 +22,17 @@ const CardItem = ({ card }: { card: CardType }) => {
       <div className="mx-auto w-11/12 h-40 bg-gray-300 rounded-xl"></div>
       <div className="card-body p-5">
         <div className="flex justify-between">
-          <div className="flex gap-4">
+          <div className="flex items-center gap-4">
             <h2 className="card-title">{card.nickname}</h2>
-            <h3 className="">{card.twitter}</h3>
+            <h3 className="">@{card.twitter}</h3>
           </div>
-          <div className="badge h-7">NEW</div>
+          {isNew && <div className="badge bg-purple-400 border-none h-8 w-14">NEW</div>}
         </div>
-        {card.customFields && (
-          <p className="w-full text-ellipsis overflow-hidden whitespace-nowrap">
-            {card.customFields[0]?.key}: {card.customFields[0]?.contents}
-          </p>
-        )}
+        <p className="w-full text-sm line-clamp-2">{card.bio}</p>
         {/* TODO: 추후 updatedAt api가 추가되면 수정 예정 */}
-        <time className="justify-start text-xs">마지막 업데이트: {card.updated_at}</time>
+        <time className="justify-start text-xs text-gray-600 pt-3">
+          업데이트: {applyDateFormatting(card.updated_at)}
+        </time>
       </div>
     </div>
   );

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -19,4 +19,5 @@ export interface CardType {
   }[];
   password: string;
   updated_at: string;
+  bio: string;
 }

--- a/src/utils/applyDateFormatting.ts
+++ b/src/utils/applyDateFormatting.ts
@@ -1,0 +1,27 @@
+import { getDifferenceInDays } from '@/utils/getDifferenceInDays';
+
+export const applyDateFormatting = (chatDate: string) => {
+  const getYYMMDD = () => {
+    const parsedChatDate = new Date(Date.parse(chatDate));
+    const year = parsedChatDate.getFullYear();
+    const month = parsedChatDate.getMonth() + 1;
+    const day = parsedChatDate.getDate();
+    return `${year}년 ${month}월 ${day}일`;
+  };
+
+  const getFormattedDate = () => {
+    const diffDays = getDifferenceInDays(chatDate);
+    const YYMMDD = getYYMMDD();
+    if (diffDays === 0) {
+      return '오늘';
+    } else if (diffDays > 0 && diffDays < 4) {
+      return `${diffDays}일 전`;
+    } else {
+      return YYMMDD;
+    }
+  };
+
+  const formattedDate = getFormattedDate();
+
+  return formattedDate;
+};

--- a/src/utils/checkIsNew.ts
+++ b/src/utils/checkIsNew.ts
@@ -1,0 +1,10 @@
+import { getDifferenceInDays } from './getDifferenceInDays';
+
+export const checkIsNew = (chatDate: string) => {
+  const diffDays = getDifferenceInDays(chatDate);
+  if (diffDays < 7) {
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/src/utils/getDifferenceInDays.ts
+++ b/src/utils/getDifferenceInDays.ts
@@ -1,0 +1,7 @@
+export const getDifferenceInDays = (date: string) => {
+  const past = new Date(date).getTime();
+  const current = new Date().getTime();
+  const differenceInDays = Math.abs(current - past);
+  const diffDays = Math.floor(differenceInDays / (1000 * 60 * 60 * 24));
+  return diffDays;
+};


### PR DESCRIPTION
# 작업 내용
- 메인페이지 카드 UI를 개선하였습니다.
- 카드 UI에서 자유형식 필드를 삭제하고 트위터 바이오(자기소개) 란을 추가하였습니다.
- 날짜 표시 포맷을 적용하였습니다.
  - 기본적으로 YYYY년 MM월 DD일로 표기하였습니다.
  - 최종 업데이트 날짜와 현재 날짜의 차이가 4일 미만이라면 '~일 전'을 적용하였습니다.
- 명함 업데이트 날짜가 최신일 시 명함에 'NEW' 뱃지 추가
  - 7일 미만일 시 최신으로 간주하였습니다.

# 스크린샷
<img width="316" alt="스크린샷 2024-02-20 오전 12 27 17" src="https://github.com/ramgee-zzik-nabi/application/assets/101965666/018cd8a3-f6a9-43c4-a4f3-62d434ab02b0">
<img width="315" alt="스크린샷 2024-02-20 오전 12 27 56" src="https://github.com/ramgee-zzik-nabi/application/assets/101965666/1b28e19b-99fd-4897-a35b-26405c6f907a">
