### PR TITLE
feat: 트위터에 공유하기 기능 추가

### DIFF
--- a/src/components/modal/BottomSheet.tsx
+++ b/src/components/modal/BottomSheet.tsx
@@ -5,7 +5,7 @@ import QRModal from '@/components/modal/QRModal';
 import { useCreateShortLink } from '@/hooks/queries/useCreateShortLink';
 import { showToastSuccessMessage } from '@/utils/showToastMessage';
 
-const BottomSheet = () => {
+const BottomSheet = ({ nickname }: { nickname: string }) => {
   const { mutate: createShortLink } = useCreateShortLink();
   const modal = useModal();
 
@@ -20,6 +20,13 @@ const BottomSheet = () => {
         },
       },
     );
+  };
+
+  const handleShareOnTwitter = () => {
+    const share_text = `${nickname}의 명함을 공유합니다! 🎉`;
+    const link = window.location.href;
+    const twitterIntent = `https://twitter.com/intent/tweet?text=${share_text}&url=${link}`;
+    window.open(twitterIntent, '_blank');
   };
 
   const handleCloseBottomSheet = () => {
@@ -38,16 +45,15 @@ const BottomSheet = () => {
           QR코드로 공유하기
         </button>
         <CopyToClipboard
-          // text={`${BASE_URL}/${cardId}`}
-          text="https://www.wonju.go.kr/www/selectBbsNttView.do?key=203&bbsNo=136&nttNo=372323&searchCtgry=&searchCnd=all&searchKrwd=&pageIndex=7&integrDeptCode="
-          onCopy={() => showToastSuccessMessage('초대링크가 복사되었습니다.')}
+          text={`${window.location.href}`}
+          onCopy={() => showToastSuccessMessage('명함 링크가 복사되었습니다.')}
         >
           <button className="w-full flex gap-3 ml-3">
             <Image width={25} height={25} src="/copy.png" alt="링크 복사" />
             링크 복사하기
           </button>
         </CopyToClipboard>
-        <button className="flex gap-3 btn w-full btn-primary">
+        <button className="flex gap-3 btn w-full btn-primary" onClick={handleShareOnTwitter}>
           <Image width={25} height={25} src="/twitter.png" alt="트위터" />
           트위터에 공유하기
         </button>

--- a/src/pages/[id]/index.tsx
+++ b/src/pages/[id]/index.tsx
@@ -9,7 +9,9 @@ import type { CardType } from '@/types/cards';
 
 const Page = ({ card }: { card: CardType }) => {
   const handleShowBottomSheet = () => {
-    NiceModal.show(BottomSheet);
+    NiceModal.show(BottomSheet, {
+      nickname: card.nickname,
+    });
   };
 
   return (


### PR DESCRIPTION
# 관련 이슈
#46 

# 작업 내용
- 트위터에 명함을 공유하는 기능을 추가하였습니다.
- '트위터에 공유하기' 버튼 클릭 시 아래의 목록이 포함되어 있는 트윗 창이 열립니다.
  - 공유하는 명함 주인의 닉네임
  - 공유하는 명함 url

# 참고한 레퍼런스
- <a href='https://velog.io/@aborile/%EC%9B%B9-%EB%A7%81%ED%81%AC-SNS-%EA%B3%B5%EC%9C%A0%ED%95%98%EA%B8%B0#%ED%8A%B8%EC%9C%84%ED%84%B0-%EA%B3%B5%EC%9C%A0'>웹-링크-SNS-공유하기#트위터-공유</a>
- https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/overview

# 스크린샷
<img width="1091" alt="image" src="https://github.com/ramgee-zzik-nabi/application/assets/101965666/2059feda-93e4-4b32-9708-b9a2a1f8f4b9">
