### PR TITLE
feat: 비밀번호 확인 기능 추가(비밀번호 두번 입력, 입력 내용 보이기/가리기)

### DIFF
--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -193,8 +193,6 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
     }
   }, [password, passwordCheck]);
 
-  console.log('passwordCheck', passwordCheck);
-
   return (
     <div className="pb-12">
       <div className="card glass bg-white shadow-md aspect-nameCard">
@@ -232,11 +230,12 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
                 className="h-10 absolute top-0 right-2"
                 onClick={() => setIsPasswordVisible((prev) => !prev)}
               >
-                {isPasswordVisible ? (
-                  <Image width={22} height={22} src="/hide.png" alt="숨김" />
-                ) : (
-                  <Image width={22} height={22} src="/view.png" alt="보임" />
-                )}
+                <Image
+                  width={22}
+                  height={22}
+                  src={isPasswordVisible ? '/hide.png' : '/view.png'}
+                  alt={isPasswordCheckVisible ? '숨김' : '보임'}
+                />
               </button>
             </div>
             {errors.password && (

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -185,12 +185,9 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
       setValue('twitterImage', urlImage);
     }
   };
+
   useEffect(() => {
-    if (password !== passwordCheck) {
-      setIsPasswordDifferent(true);
-    } else {
-      setIsPasswordDifferent(false);
-    }
+    setIsPasswordDifferent(passwordCheck !== '' && password !== passwordCheck);
   }, [password, passwordCheck]);
 
   return (


### PR DESCRIPTION
# 관련 이슈
#49 

# 작업 내용
- 입력한 비밀번호를 확인할 수 있는 기능을 추가하였습니다.
  - 우측의 눈이 감긴 아이콘을 클릭하면 입력한 비밀번호가 보이며 눈이 감긴 아이콘으로 변경됩니다.
  - 다시 눈이 감긴 아이콘을 클릭하면 입력한 비밀번호가 가려지며 눈을 뜬 아이콘으로 변경됩니다.
- 비밀번호를 두번 입력하여 일치하는지를 확인하는 기능을 추가하였습니다.
  - 비밀번호 필드와 비밀번호 확인 필드 입력값이 동일하지 않을 시 하단에 오류 메시지가 뜹니다. 

# 스크린샷(gif)
<img src='https://github.com/ramgee-zzik-nabi/application/assets/101965666/ff6a7814-e4da-42f1-83da-d4e6127e7ddc' width='40%'>
