### PR TITLE
feat: 불필요한 state 제거, watch문 사용

### DIFF
--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useCreateCard } from '@/hooks/queries/useCreateCard';
 import { useUpdateCard } from '@/hooks/queries/useUpdateCard';
@@ -39,7 +39,6 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
   // const renderError = (error?: ErrorObject) => error.message && <p>{error.message}</p>
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [isPasswordCheckVisible, setIsPasswordCheckVisible] = useState(false);
-  const [isPasswordDifferent, setIsPasswordDifferent] = useState(false);
   const {
     register,
     handleSubmit,
@@ -186,10 +185,6 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
     }
   };
 
-  useEffect(() => {
-    setIsPasswordDifferent(passwordCheck !== '' && password !== passwordCheck);
-  }, [password, passwordCheck]);
-
   return (
     <div className="pb-12">
       <div className="card glass bg-white shadow-md aspect-nameCard">
@@ -270,7 +265,8 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
                 <span className="label-text text-red-500 ">{requiredSentence}</span>
               </div>
             )}
-            {isPasswordDifferent && passwordCheck !== '' && (
+
+            {password !== passwordCheck && passwordCheck !== '' && passwordCheck !== undefined && (
               <div className="label pt-0.5">
                 <span className="label-text text-red-500 ">비밀번호가 일치하지 않습니다.</span>
               </div>


### PR DESCRIPTION
# 작업 내용
- 불필요한 state인 isPasswordDifferent, setIsPasswordDifferent를 제거하고 watch문을 사용하였습니다.

# 고민
비밀번호가 일치하지 않을 때 에러메시지를 띄우기 위해 아래와 같이 조건부렌더링을 하였습니다.

'비밀번호가 일치하지 않습니다' 에러 메시지가 보여야 하는 상황은 아래의 상황을 모두 만족할 때입니다. 그래서 이렇게 조건문을 길게 썼는데, 이 방법이 최선인지 궁금합니다.

1. 비밀번호가 잍치하지 않을 때
2. 비밀번호 확인 입력란이 빈칸이 아닐 때(빈칸이면 비밀번호가 일치하지 않는 게 아니라 아직 입력을 안한 거라고 간주)
3. 비밀번호 확인 입력란이 undefined일 때(초기 렌더링 시에 왜인지 undefined로 설정되어 있음)

```tsx
{password !== passwordCheck && passwordCheck !== '' && passwordCheck !== undefined && (
  <div className="label pt-0.5">
    <span className="label-text text-red-500 ">비밀번호가 일치하지 않습니다.</span>
  </div>
)}
```