### PR TITLE
feat: 폼 유효성 검사 추가

### DIFF
--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -321,7 +321,7 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
                 type="text"
                 placeholder=""
                 className="input h-10 w-full max-w-xs shadow-sm placeholder:text-xs"
-                {...register('twitterNickname', { required: true })}
+                {...register('twitterNickname', { required: true, maxLength: 15 })}
                 name="twitterNickname"
               />
               {errors.twitterNickname && (
@@ -337,7 +337,7 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
               <textarea
                 className="textarea w-full max-w-xs shadow-sm h-28 placeholder:text-xs"
                 placeholder=""
-                {...register('twitterBio')}
+                {...register('twitterBio', { maxLength: 160 })}
               />
             </label>
             <div className="form-control w-full max-w-xs">
@@ -415,7 +415,7 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
                 type="text"
                 placeholder=""
                 className="input h-10 w-1/2 max-w-xs shadow-sm placeholder:text-xs"
-                {...register('instagramId')}
+                {...register('instagramId', { maxLength: 30 })}
                 name="instagramId"
               />
             </label>
@@ -427,7 +427,7 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
                 type="text"
                 placeholder=""
                 className="input w-1/2 h-10 max-w-xs shadow-sm placeholder:text-xs"
-                {...register('githubId')}
+                {...register('githubId', { maxLength: 30 })}
                 name="githubId"
               />
             </label>

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -112,8 +112,10 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
   };
 
   const submitHandler = (data: Data) => {
+    const customFields = data.customFields.filter((field) => field.key.trim() !== '' && field.contents.trim() !== '');
+
     const allData = {
-      customFields: data.customFields,
+      customFields,
       socialMedia: { instagram: data.instagramId.trim(), github: data.githubId.trim(), blog: data.blog.trim() },
       nickname: data.twitterNickname,
       twitter: data.twitterId,

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -43,7 +43,8 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [isPasswordCheckVisible, setIsPasswordCheckVisible] = useState(false);
   const setSelectedCardId = useSetRecoilState(selectedCardIdState);
-
+  const [isMaxHashtagList, setIsMaxHashtagList] = useState(false);
+  const [isMaxHashtag, setIsMaxHashtag] = useState(false);
   const {
     register,
     handleSubmit,
@@ -97,8 +98,12 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
     if (!event.nativeEvent.isComposing && event.key === 'Enter') {
       event.preventDefault();
       const newHashtag = (event.target as HTMLInputElement).value.trim();
-
+      if (newHashtag.length > 15) setIsMaxHashtag(true);
       if (newHashtag && !hashtagList.includes(newHashtag)) {
+        if (hashtagList.length > 3) {
+          setIsMaxHashtagList(true);
+          return;
+        }
         setHashtagList([...hashtagList, newHashtag]); // 새 해시태그 추가
         setHashtagInput('');
         setShowDropdown(false);
@@ -407,6 +412,16 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
                 </div>
               ))}
             </div>
+            {isMaxHashtag && (
+              <div className="label pt-0.5">
+                <span className="label-text text-red-500">해시태그는 15글자 이하여야 해요.</span>
+              </div>
+            )}
+            {isMaxHashtagList && (
+              <div className="label pt-0.5">
+                <span className="label-text text-red-500">해시태그는 4개까지 작성할 수 있어요.</span>
+              </div>
+            )}
           </label>
         </fieldset>
         <fieldset>

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -107,7 +107,6 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
           setIsMaxHashtagList(true);
           return;
         }
-        console.log('isMaxHashtagList', isMaxHashtagList);
         setHashtagList([...hashtagList, newHashtag]); // 새 해시태그 추가
         setHashtagInput('');
         setShowDropdown(false);

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
 import { useCreateCard } from '@/hooks/queries/useCreateCard';
@@ -98,12 +98,16 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
     if (!event.nativeEvent.isComposing && event.key === 'Enter') {
       event.preventDefault();
       const newHashtag = (event.target as HTMLInputElement).value.trim();
-      if (newHashtag.length > 15) setIsMaxHashtag(true);
+      if (newHashtag.length > 15) {
+        setIsMaxHashtag(true);
+        return;
+      }
       if (newHashtag && !hashtagList.includes(newHashtag)) {
         if (hashtagList.length > 3) {
           setIsMaxHashtagList(true);
           return;
         }
+        console.log('isMaxHashtagList', isMaxHashtagList);
         setHashtagList([...hashtagList, newHashtag]); // 새 해시태그 추가
         setHashtagInput('');
         setShowDropdown(false);
@@ -199,6 +203,20 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
       setValue('twitterImage', urlImage);
     }
   };
+
+  useEffect(() => {
+    if (hashtagList.length <= 4) {
+      setIsMaxHashtagList(false);
+    }
+  }, [hashtagList]);
+
+  useEffect(() => {
+    hashtagList.map((hashtag) => {
+      if (hashtag.length <= 15) {
+        setIsMaxHashtag(false);
+      }
+    });
+  }, [hashtagList]);
 
   return (
     <div className="pb-12">

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -332,13 +332,18 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
             </label>
             <label className="form-control w-full max-w-xs">
               <div className="label pb-0.5">
-                <span className="label-text">자기소개</span>
+                <span className="label-text">바이오</span>
               </div>
               <textarea
                 className="textarea w-full max-w-xs shadow-sm h-28 placeholder:text-xs"
                 placeholder=""
                 {...register('twitterBio', { maxLength: 160 })}
               />
+              {errors.twitterBio && (
+                <div className="label pt-0.5">
+                  <span className="label-text text-red-500">바이오는 160자 이하여야 합니다.</span>
+                </div>
+              )}
             </label>
             <div className="form-control w-full max-w-xs">
               <label className="label pb-0.5">

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -42,7 +42,6 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
   // const renderError = (error?: ErrorObject) => error.message && <p>{error.message}</p>
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [isPasswordCheckVisible, setIsPasswordCheckVisible] = useState(false);
-  const [isPasswordDifferent, setIsPasswordDifferent] = useState(false);
   const setSelectedCardId = useSetRecoilState(selectedCardIdState);
 
   const {
@@ -115,7 +114,7 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
   const submitHandler = (data: Data) => {
     const allData = {
       customFields: data.customFields,
-      socialMedia: { instagram: data.instagramId, github: data.githubId, blog: data.blog },
+      socialMedia: { instagram: data.instagramId.trim(), github: data.githubId.trim(), blog: data.blog.trim() },
       nickname: data.twitterNickname,
       twitter: data.twitterId,
       bio: data.twitterBio,

--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -43,14 +43,13 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [isPasswordCheckVisible, setIsPasswordCheckVisible] = useState(false);
   const setSelectedCardId = useSetRecoilState(selectedCardIdState);
-  const [isMaxHashtagList, setIsMaxHashtagList] = useState(false);
-  const [isMaxHashtag, setIsMaxHashtag] = useState(false);
   const {
     register,
     handleSubmit,
     watch,
     formState: { errors },
     setValue,
+    setError,
   } = useForm<Data>({
     defaultValues:
       cardId === null
@@ -98,13 +97,15 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
     if (!event.nativeEvent.isComposing && event.key === 'Enter') {
       event.preventDefault();
       const newHashtag = (event.target as HTMLInputElement).value.trim();
+
       if (newHashtag.length > 15) {
-        setIsMaxHashtag(true);
+        setError('hashtags', { message: '해시태그는 15글자 이하여야 해요.' });
         return;
       }
+
       if (newHashtag && !hashtagList.includes(newHashtag)) {
         if (hashtagList.length > 3) {
-          setIsMaxHashtagList(true);
+          setError('hashtags', { message: '해시태그는 4개까지 작성할 수 있어요.' });
           return;
         }
         setHashtagList([...hashtagList, newHashtag]); // 새 해시태그 추가
@@ -112,6 +113,7 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
         setShowDropdown(false);
       }
     }
+    setError('hashtags', { message: '' });
     setShowDropdown(true);
   };
 
@@ -202,20 +204,6 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
       setValue('twitterImage', urlImage);
     }
   };
-
-  useEffect(() => {
-    if (hashtagList.length <= 4) {
-      setIsMaxHashtagList(false);
-    }
-  }, [hashtagList]);
-
-  useEffect(() => {
-    hashtagList.map((hashtag) => {
-      if (hashtag.length <= 15) {
-        setIsMaxHashtag(false);
-      }
-    });
-  }, [hashtagList]);
 
   return (
     <div className="pb-12">
@@ -429,16 +417,8 @@ const CardForm = ({ cardId }: { cardId: string | null }) => {
                 </div>
               ))}
             </div>
-            {isMaxHashtag && (
-              <div className="label pt-0.5">
-                <span className="label-text text-red-500">해시태그는 15글자 이하여야 해요.</span>
-              </div>
-            )}
-            {isMaxHashtagList && (
-              <div className="label pt-0.5">
-                <span className="label-text text-red-500">해시태그는 4개까지 작성할 수 있어요.</span>
-              </div>
-            )}
+            {/* ------------------------- */}
+            {errors.hashtags && <span className="label-text text-red-500">{errors.hashtags.message}</span>}
           </label>
         </fieldset>
         <fieldset>

--- a/src/pages/[id]/edit/index.tsx
+++ b/src/pages/[id]/edit/index.tsx
@@ -3,7 +3,6 @@ import CardForm from '@/components/card/CardForm';
 import LayoutWithTitle from '@/components/layout/LayoutWithTitle';
 
 const Page = ({ cardId }: { cardId: string }) => {
-  console.log('cardId front: ', cardId);
   return <CardForm cardId={cardId} />;
 };
 
@@ -13,7 +12,6 @@ Page.getLayout = function getLayout(page) {
 
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
   const cardId = context.params?.id;
-  console.log('cardId: ', cardId);
   return {
     props: { cardId },
   };

--- a/src/utils/showToastMessage.ts
+++ b/src/utils/showToastMessage.ts
@@ -31,7 +31,6 @@ export const showToastPromiseMessage = (promise, message) => {
     loading: message.loading,
     success: message.success,
     error: (error) => {
-      console.log('error', error);
       return error.response.data.message;
     },
   });


### PR DESCRIPTION
# 관련 이슈
#28 

# 작업 내용
- 폼 유효성 검사를 추가하였습니다.
  - 공백은 서버에 값이 올라가지 않도록 처리하였습니다.
  - 최대 글자수를 추가하였습니다.
  - 해시태그 최대 개수를 4개로 설정하였습니다.
  -  값이 유효하지 않을 시 에러 메시지를 필드 아래에 보여지게 하고, 유효성 충족 시 에러 메시지를 보이지 않게 처리하였습니다.