### PR TITLE
feat: 명함 이미지 로딩시 배경 설정

### DIFF
--- a/src/components/card/CardItem.tsx
+++ b/src/components/card/CardItem.tsx
@@ -22,8 +22,9 @@ const CardItem = ({ card }: { card: CardType }) => {
       <div className="m-2 border-gray-400 border">
         <img
           src={`${process.env.NEXT_PUBLIC_FRONTEND_URL}/api/cards/${card.id}/thumbnail`}
-          alt=""
+          alt="트위터 명함"
           className="aspect-nameCard"
+          style={{ width: '100rem', backgroundColor: 'white' }}
         />
       </div>
       <div className="card-body px-5 py-3">

--- a/src/components/ui/BottomNavigation.tsx
+++ b/src/components/ui/BottomNavigation.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { type ComponentProps, memo } from 'react';
+import { useEffect, useState } from 'react';
 import CardIcon from '../icons/CardIcon';
 import CreateIcon from '../icons/CreateIcon';
 import HomeIcon from '../icons/HomeIcon';
@@ -15,6 +16,7 @@ export const navIconColors = {
 } as const;
 
 export default function BottomNavigation() {
+  const [isClient, setIsClient] = useState(false);
   const cardId = globalThis.localStorage?.getItem('cardId');
   const NAV_ITEMS = [
     { href: '/', Icon: HomeIcon, label: '홈' },
@@ -41,11 +43,19 @@ export default function BottomNavigation() {
   });
   NavItem.displayName = 'NavItem';
 
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
   return (
-    <nav className="btm-nav btm-nav-lg max-w-[512px] mx-auto z-20">
-      {NAV_ITEMS.map((navItem) => (
-        <NavItem key={navItem.href} {...navItem} />
-      ))}
-    </nav>
+    <>
+      {isClient && (
+        <nav className="btm-nav btm-nav-lg max-w-[512px] mx-auto z-20">
+          {NAV_ITEMS.map((navItem) => (
+            <NavItem key={navItem.href} {...navItem} />
+          ))}
+        </nav>
+      )}
+    </>
   );
 }

--- a/src/pages/card/[cardId]/index.tsx
+++ b/src/pages/card/[cardId]/index.tsx
@@ -37,6 +37,7 @@ const Page = ({ card }: { card: CardType }) => {
             src={`${process.env.NEXT_PUBLIC_FRONTEND_URL}/api/cards/${card.id}/thumbnail`}
             className="w-full aspect-nameCard"
             alt="명함 이미지"
+            style={{ width: '100rem', backgroundColor: 'white' }}
           />
         </div>
         <div className="flex justify-around">


### PR DESCRIPTION
# 작업 내용
- 명함 이미지 로딩 시 너비와 배경색을 주어 빈 이미지가 보이도록 하였습니다.
- 네비게이션바 색 하이드레이션 오류를 해결하였습니다.