### PR TITLE
fix: QR코드 중앙에 있는 이미지를 표시하지 못하는 오류 해결

### DIFF
--- a/src/components/SEO/SEO.tsx
+++ b/src/components/SEO/SEO.tsx
@@ -4,15 +4,16 @@ import { useRouter } from 'next/router';
 interface Props {
   title?: string;
   description?: string;
+  imageUrl?: string;
 }
 
-export default function SEO({ title, description }: Props) {
+export default function SEO({ title, description, imageUrl }: Props) {
   const router = useRouter();
 
   const pageTitle = title ? `${title} | 트위터 명함` : '트위터 명함';
   const pageDescription = description || '나만의 트위터 명함을 만들고 공유해보아요! 🐥';
   const pageUrl = 'https://twitter-namecard.vercel.app' + router.asPath;
-  const pageImage = '/images/naramzik-namecard.png';
+  const pageImage = imageUrl || '/images/naramzik-namecard.png';
 
   return (
     <Head>

--- a/src/pages/card/[cardId]/index.tsx
+++ b/src/pages/card/[cardId]/index.tsx
@@ -26,10 +26,13 @@ const Page = ({ card }: { card: CardType }) => {
       },
     );
   };
-
+  console.log('card.image_url', card.image_url);
   return (
     <>
-      <SEO description={`${card.nickname}님의 명함을 둘러보세요.`} />
+      <SEO
+        description={`${card.nickname}님의 명함을 둘러보세요.`}
+        imageUrl={`${process.env.NEXT_PUBLIC_FRONTEND_URL}/api/cards/${card.id}/thumbnail`}
+      />
       <div className="mb-16">
         <h1 className="text-2xl font-bold">{card.nickname}</h1>
         <div className="flex justify-center h-1/4 py-3">

--- a/src/pages/card/[cardId]/index.tsx
+++ b/src/pages/card/[cardId]/index.tsx
@@ -1,4 +1,5 @@
 import NiceModal from '@ebay/nice-modal-react';
+import axios from 'axios';
 import Image from 'next/image';
 import Link from 'next/link';
 import randomColor from 'randomcolor';
@@ -9,7 +10,6 @@ import BottomSheet from '@/components/modal/BottomSheet';
 import SEO from '@/components/SEO/SEO';
 import { useCreateShortLink } from '@/hooks/queries/useCreateShortLink';
 import { getTextColor } from '@/hooks/styles/getTextColor';
-import prisma from '@/utils/prisma';
 import { showToastSuccessMessage } from '@/utils/showToastMessage';
 import type { GetServerSidePropsContext } from 'next';
 import type { CardType } from '@/types/cards';
@@ -182,16 +182,12 @@ Page.getLayout = function getLayout(page: ReactNode) {
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
   try {
     const cardId = context.params?.cardId;
-    const card = await prisma.cards.findFirstOrThrow({
-      where: {
-        id: cardId as string,
-      },
-    });
+    const card = await axios.get(`${process.env.NEXT_PUBLIC_FRONTEND_URL}/api/cards/${cardId}`);
     return {
       props: {
         card: {
-          ...card,
-          updated_at: card.updated_at.toString(),
+          ...card.data.foundCard,
+          updated_at: card.data.foundCard.updated_at.toString(),
         },
       },
     };

--- a/src/pages/card/[cardId]/index.tsx
+++ b/src/pages/card/[cardId]/index.tsx
@@ -26,7 +26,6 @@ const Page = ({ card }: { card: CardType }) => {
       },
     );
   };
-  console.log('card.image_url', card.image_url);
   return (
     <>
       <SEO


### PR DESCRIPTION
# 작업 내용
- QR 코드 중앙에 위치한 이미지 src인 image_url이 cardId로 불러와지는 오류를 해결하였습니다.
- 기존처럼 prisma에서 card 데이터를 가져왔을 때 image_url이 cardId와 동일한 오류가 있었는데, /api/cards/${cardId} api에서 불러왔을 때는 image_url이 정상적으로 불러와지는 것을 확인하여 card 데이터를 가져오는 코드를 변경하였습니다.

# 추가 작업
(따로 브랜치를 판 줄 알았는데 아니어서 함께 올립니다)
- 링크 공유시 썸네일에 개별화된 명함 이미지가 보이도록 url을 수정하였습니다.