### PR TITLE
feat: 에러 메시지 추가

### DIFF
--- a/src/utils/showToastMessage.ts
+++ b/src/utils/showToastMessage.ts
@@ -12,7 +12,8 @@ const toastMessage = (message: string, type: ToastType) => {
 export const showToastErrorMessage = (error: unknown) => {
   if (error instanceof AxiosError) {
     const errorResponse = error.response?.data?.message ?? '서버 에러가 발생했습니다.';
-    if (errorResponse === '비밀번호가 일치하지 않습니다.') {
+    console.log(errorResponse);
+    if (errorResponse === '비밀번호가 일치하지 않습니다.' || errorResponse === '비밀번호는 6자 이상으로 필수입니다.') {
       toast.error(errorResponse);
     } else {
       toast.error('서버 에러가 발생했습니다.');


### PR DESCRIPTION
# 작업 내용
- 에러 메시지가 '비밀번호는 6자 이상으로 필수입니다.'일 때 해당 에러 메시지 클라이언트에 띄우기