### PR TITLE
feat: 명함 컴포넌트 UI 수정 및 바이오 글자수 제한 설정

### DIFF
--- a/src/components/card/CardForm.tsx
+++ b/src/components/card/CardForm.tsx
@@ -210,7 +210,15 @@ const CardForm = ({ card, onSubmit = noop }: CardFormProps) => {
 
           <FormLabel label="바이오" errorMessage={errors.bio?.message}>
             <TextArea
-              {...register('bio')}
+              {...register('bio', {
+                onChange: (e) => {
+                  if (e.target.value.length > 80) {
+                    setError('bio', { message: '바이오는 80자 이하여야 합니다.' });
+                  } else {
+                    clearErrors('bio');
+                  }
+                },
+              })}
               placeholder="바이오를 입력해주세요"
               rows={7}
               readOnly={isCreateMode && !isSuccess}

--- a/src/components/card/NameCard.tsx
+++ b/src/components/card/NameCard.tsx
@@ -43,8 +43,8 @@ const NameCard = ({
       >
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           <span style={{ fontSize: '1.5em', lineHeight: 1, fontWeight: 'bold' }}>{twitterNickname}</span>
-          <span style={{ fontSize: '1em', lineHeight: 1 }}>@{twitterId ?? 'anonymous'}</span>
-          {twitterBio && <span style={{ fontSize: '0.5em', marginTop: '0.5em' }}>"{twitterBio}"</span>}
+          <span style={{ fontSize: '1.1em', lineHeight: 1 }}>@{twitterId ?? 'anonymous'}</span>
+          {twitterBio && <span style={{ fontSize: '0.7em', marginTop: '0.5em' }}>"{twitterBio}"</span>}
         </div>
         {hashtags && (
           <div style={{ display: 'flex', gap: '0.5em', flexWrap: 'wrap', width: '200px' }}>

--- a/src/pages/api/cards/[cardId]/thumbnail.tsx
+++ b/src/pages/api/cards/[cardId]/thumbnail.tsx
@@ -48,8 +48,10 @@ export default async function handler(request: NextRequest) {
           >
             <div style={{ display: 'flex', flexDirection: 'column' }}>
               <span style={{ fontSize: '2em', lineHeight: 1, fontWeight: 'bold' }}>{foundCard.nickname}</span>
-              <span style={{ fontSize: '1em', lineHeight: 1 }}>@{foundCard.twitter ?? 'anonymous'}</span>
-              {foundCard.bio && <span style={{ fontSize: '0.73em', marginTop: '0.5em' }}>"{foundCard.bio}"</span>}
+              <span style={{ fontSize: '1.5em', lineHeight: 1 }}>@{foundCard.twitter ?? 'anonymous'}</span>
+              {foundCard.bio && (
+                <span style={{ fontSize: '1em', marginTop: '0.5em', width: '26.1em' }}>"{foundCard.bio}"</span>
+              )}
             </div>
             {foundCard.hashtags && (
               <div


### PR DESCRIPTION
# 작업 내용
- 명함 컴포넌트에서 트위터 아이디, 바이오의 글자 크기를 확대하였습니다.
- 바이오 최대 글자수를 80글자로 제한하였습니다.

# 기타 
- @cottonpup 서버쪽 명함 컴포넌트도 이 컴포넌트로 수정 부탁드립니다!