### PR TITLE
fix: 스크롤이 끝까지 내려가도 다음 페이지가 불려오지 않는 오류 해결

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,9 @@ export default function Home() {
   useEffect(() => {
     function handleScroll() {
       const { scrollTop, scrollHeight } = document.documentElement;
-      if (scrollTop + window.innerHeight >= scrollHeight) {
+      const gap = 500;
+      if (scrollTop + window.innerHeight >= scrollHeight - gap) {
+        console.log('fetchNextPage');
         fetchNextPage();
       }
     }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,6 @@ export default function Home() {
       const { scrollTop, scrollHeight } = document.documentElement;
       const gap = 500;
       if (scrollTop + window.innerHeight >= scrollHeight - gap) {
-        console.log('fetchNextPage');
         fetchNextPage();
       }
     }


### PR DESCRIPTION
# 작업 내용
스크롤이 끝까지 내려가도 다음 페이지를 불러오는 함수인 fetchNextPage()가 실행되지 않는 오류를 해결하였습니다.

fetchNextPage()가 실행되는 부분에서 콘솔을 찍어보니 스크롤을 끝까지 내려도 `scrollTop + window.innerHeight`가 `scrollHeight` 이상이 되지 않는 상태였습니다. 

```tsx
if (scrollTop + window.innerHeight >= scrollHeight) {
   fetchNextPage();
}
```

![스크롤](https://github.com/naramzik/twitter-namecard/assets/101965666/f8cdf9ce-62e4-4152-9aae-66dc9b3066a1)

그래서 스크롤이 바닥에 닿기 전에 다음 페이지를 불러올 수 있도록 바닥에서 `gap`만큼 떨어져있으면 그때 다음 페이지를 불러올 수 있도록 수정하였습니다. 이렇게 되면 사용자 입장에서 다음 페이지를 다음 페이지 로딩을 위해 조금 덜 기다려도 되고, 오류도 해결될 것 같습니다.

```tsx
const gap = 500;
if (scrollTop + window.innerHeight >= scrollHeight - gap) {
  fetchNextPage();
}
```

# 기타
제가 해결한 방법이 맞지 않다면 알려주시거나 수정해주세요!
